### PR TITLE
Appending rows to empty tables

### DIFF
--- a/editablegrid.js
+++ b/editablegrid.js
@@ -1208,7 +1208,7 @@ EditableGrid.prototype._insert = function(rowIndex, offset, rowId, cellValues, r
 EditableGrid.prototype.insert = function(rowIndex, rowId, cellValues, rowAttributes, dontSort)
 {
 	if (rowIndex < 0) rowIndex = 0;
-	if (rowIndex >= this.data.length) return this.insertAfter(this.data.length - 1, rowId, cellValues, rowAttributes, dontSort);
+	if (rowIndex >= this.data.length && this.data.legth > 0) return this.insertAfter(this.data.length - 1, rowId, cellValues, rowAttributes, dontSort);
 	return this._insert(rowIndex, 0, rowId, cellValues, rowAttributes, dontSort);
 };
 


### PR DESCRIPTION
Fixed adding row to an empty table: 

when append() is called on an empty table, it invokes insertAfter() passing rowIndex=(data.length-1)=-1. 
This triggers a call to insert() with rowIndex = 0. 

At this point however (rowIndex = data.length) which would trigger a call to insertAfter() with rowIndex=-1 again! 

Thus we get stuck in an infinite mutual call between insertAfter() and insert(). 

I have added a check to make sure we only make a second call to insertAfter if data.length > 0.
