### PR TITLE
Enable repeating row selects

### DIFF
--- a/editablegrid.js
+++ b/editablegrid.js
@@ -1848,7 +1848,7 @@ EditableGrid.prototype.editCell = function(rowIndex, columnIndex)
 		if (column) {
 
 			// if another row has been selected: callback
-			if (rowIndex > -1 && rowIndex != lastSelectedRowIndex) {
+			if (rowIndex > -1) {
 				rowSelected(lastSelectedRowIndex, rowIndex);				
 				lastSelectedRowIndex = rowIndex;
 			}


### PR DESCRIPTION
The library consumer should be able to decide if he wants to react to a repeating row selection or not.