### PR TITLE
Fixed the ability to sort columns that use integers.

### DIFF
--- a/editablegrid_utils.js
+++ b/editablegrid_utils.js
@@ -124,8 +124,15 @@ EditableGrid.prototype.sort_alpha = function(a,b)
 	if (!a[0] && !b[0]) return 0;
 	if (a[0] && !b[0]) return 1;
 	if (!a[0] && b[0]) return -1;
-	if (a[0].toLowerCase()==b[0].toLowerCase()) return 0;
-	return a[0].toLowerCase().localeCompare(b[0].toLowerCase());
+
+    if (isNaN(a[0])) {
+        if (a[0].toLowerCase()==b[0].toLowerCase()) return 0;
+        return a[0].toLowerCase().localeCompare(b[0].toLowerCase());
+	} else {
+        if (a[0] === b[0]) return 0;
+        if (a[0] > b[0]) return 1;
+        return -1;
+	}
 };
 
 EditableGrid.prototype.sort_date = function(a,b) 


### PR DESCRIPTION
Currently there is a bug that exists if you attempt to sort columns that have integers values. Currently sorting columns with integers results in an exception referencing ".toLowerCase".

This code change determines if the values are ints, and if not, uses the current code, otherwise sorts by integer value.